### PR TITLE
Support RedHat capabilities on Brown Hat hardware

### DIFF
--- a/Sketchbook/LNFP_M5Stick/LNFP_M5Stick.ino
+++ b/Sketchbook/LNFP_M5Stick/LNFP_M5Stick.ino
@@ -737,7 +737,7 @@ void setup()
     else 
       Serial.println("LED Chain not activated");
 
-    if (useHat.devId == 2) //BrownHat USB Serial Injector
+    if (useHat.devId == 2 || (useHat.devId == 6 && useInterface.devId == 18)) //BrownHat USB Serial Injector -or- BrownHat running RedHat-style LocoNet Serial to DCC++EX
     {
       jsonDataObj = getDocPtr("/configdata/usb.cfg", false);
       if (jsonDataObj != NULL)
@@ -912,7 +912,8 @@ void setup()
       {
         Serial.println("Load DCC++Ex communication interface"); 
         subnetMode = fullMaster;
-        digitraxBuffer->setRedHatMode(sendLocoNetReply, *jsonDataObj); //function hooks in DigitraxBuffers
+        bool useAltPort = (useInterface.devId == 18);  //use alternate port with the LocoNet serial interface
+        digitraxBuffer->setRedHatMode(sendLocoNetReply, *jsonDataObj, useAltPort); //function hooks in DigitraxBuffers
         if (lnSerial)
         {
           lnSerial->setNetworkType(subnetMode); 

--- a/Sketchbook/LNFP_M5Stick/data/configdata/node.cfg
+++ b/Sketchbook/LNFP_M5Stick/data/configdata/node.cfg
@@ -49,7 +49,7 @@
 		"Name": "Red Hat Shield",
 		"HatId": 6,
 		"Type": 0,
-		"InterfaceList": [2, 16]
+		"InterfaceList": [2, 16, 18]
 	}, {
 		"Name": "Black Hat",
 		"HatId": 5,
@@ -98,6 +98,11 @@
 		"Type": 1,
 		"ReqSTA": 1
 	}, {
+		"Name": "LocoNet Serial",
+		"IntfId": 18,
+		"Type": 1,
+		"ReqSTA": 1
+	}, {
 		"Name": "WiThrottle Client",
 		"IntfId": 17,
 		"Type": 2,
@@ -118,7 +123,7 @@
 	{
 		"Name": "Loconet lbServer",
 		"ServerId": 1,
-		"InterfaceList": [2, 3, 12, 16],
+		"InterfaceList": [2, 3, 12, 16, 18],
 		"Type": 1
 	},
 	{

--- a/Sketchbook/LNFP_M5Stick/data/configdata/rhcfg.cfg
+++ b/Sketchbook/LNFP_M5Stick/data/configdata/rhcfg.cfg
@@ -2,6 +2,8 @@
 	"Version": "1.0.1",
 	"TxD": 26,
 	"RxD": 36,
+	"AltTxD": 26,
+	"AltRxD": 36,
 	"BaudRate": 115200,
 	"Invert": false,
 	"DevSettings": {

--- a/Sketchbook/libraries/IoTT_DigitraxBuffers/src/IoTT_DigitraxBuffers.cpp
+++ b/Sketchbook/libraries/IoTT_DigitraxBuffers/src/IoTT_DigitraxBuffers.cpp
@@ -453,13 +453,19 @@ IoTT_DigitraxBuffers::~IoTT_DigitraxBuffers()
 {
 }
 
-void IoTT_DigitraxBuffers::loadRHCfgJSON(DynamicJsonDocument doc)
+void IoTT_DigitraxBuffers::loadRHCfgJSON(DynamicJsonDocument doc, bool useAltPort)
 {
 //	Serial.println("Load JSON");
-	if (doc.containsKey("RxD"))
-		rxPin = doc["RxD"];
-	if (doc.containsKey("TxD"))
-		txPin = doc["TxD"];
+	if (useAltPort)
+	{
+		if (doc.containsKey("AltRxD")) { rxPin = doc["AltRxD"]; }
+		if (doc.containsKey("AltTxD")) { txPin = doc["AltTxD"]; }
+	}
+	else
+	{
+		if (doc.containsKey("RxD")) { rxPin = doc["RxD"]; }
+		if (doc.containsKey("TxD")) { txPin = doc["TxD"]; }
+	}
 	if (doc.containsKey("DevSettings"))
 	{
 		JsonObject thisObj = doc["DevSettings"];
@@ -629,12 +635,12 @@ bool IoTT_DigitraxBuffers::cnTreeValid(uint8_t ofSlot, uint8_t cnLevel)
 	return true;
 }
 
-void IoTT_DigitraxBuffers::setRedHatMode(txFct lnReply, DynamicJsonDocument doc)
+void IoTT_DigitraxBuffers::setRedHatMode(txFct lnReply, DynamicJsonDocument doc, bool useAltPort)
 {
 	memcpy(&slotBuffer[0x7B], &stdSlot[0], 10);
 	memcpy(&slotBuffer[0x7C], &stdSlot[0], 10);
 	lnReplyFct = lnReply;
-	loadRHCfgJSON(doc);
+	loadRHCfgJSON(doc, useAltPort);
 	isCommandStation = lnReply != NULL;
 	if (dccPort == NULL)
 	{


### PR DESCRIPTION
The concept for this pull request is to support interfacing computer-based LocoNet software application with a DCC++EX command station.  Currently, the [Brown Hat USB Interface](https://www.tindie.com/products/tanner87661/brownhat-usb-interface/) supports the LocoBuffer-style connection with a computer, while the [Red Hat Shield](https://www.tindie.com/products/tanner87661/redhat-shield-with-arduino-headers/) supports running DCC++EX as a LocoNet command station.

The USB-C to TTL connection would still be on the M5Stick header side (like per the typical [Brown Hat USB Interface](https://www.tindie.com/products/tanner87661/brownhat-usb-interface/) configuration), but the connection on the Grove connector side would be configured to be a serial interface with DCC++EX (e.g. by using a Grove port jumper cable, either [male](https://www.tindie.com/products/tanner87661/grove-port-jumper-cable-200mm-787-male/) or [female](https://www.tindie.com/products/tanner87661/grove-port-jumper-cable-200mm-787-female/)).

I will highlight a few things that might warrant particular review by someone more intimately familiar with the codebase:
 * node.cfg: The configuration updates to add an interface for "LocoNet Serial"
 * Is there anything else that might need to be done so that the Grove connection to the LocoNet side of the Red Hat Shield does not get activated and interfere with the DCC++EX connection that was setup on the Grove connection pins?

Thank you!